### PR TITLE
Fix: Reduce vertical spacing in inline dream editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -763,7 +763,7 @@ GNU Affero General Public License for more details.
         
         /* Compact spacing for inline edit forms */
         .entry.inline-edit-form .form-group {
-            margin-bottom: 12px !important;
+            margin-bottom: 4px !important;
         }
         
         .entry.inline-edit-form .form-group label {
@@ -803,14 +803,14 @@ GNU Affero General Public License for more details.
         }
         
         .entry.inline-edit-form .lucid-checkbox {
-            margin-bottom: 12px !important;
+            margin-bottom: 4px !important;
             display: flex !important;
             align-items: center !important;
             gap: 8px !important;
         }
         
         .entry.inline-edit-form .edit-actions {
-            margin-top: 15px;
+            margin-top: 4px;
             display: flex;
             gap: 10px;
         }
@@ -2292,7 +2292,6 @@ GNU Affero General Public License for more details.
             font-size: 12px;
             opacity: 0.8;
         }
-
 
     </style>
 </head>


### PR DESCRIPTION
Reduced the `margin-bottom` on form groups and checkboxes, and the `margin-top` on the action buttons from 12-15px down to 4px to create a more compact layout, as requested.