### PR TITLE
Fix: Correct broken back/cancel buttons in PIN recovery flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ GNU Affero General Public License for more details.
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dream Journal</title>
     <style>
-        /* === DREAM JOURNAL OPTIMIZED CSS v1.32.10 === */
+        /* === DREAM JOURNAL OPTIMIZED CSS v1.32.11 === */
         /* HSL Theme System + Utility Classes - 90% reduction in theme CSS + Phase 2C voice optimization */
         /* === OPTIMIZED HSL THEME SYSTEM === */
         
@@ -2428,7 +2428,7 @@ GNU Affero General Public License for more details.
                 Licensed under <a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" style="color: var(--primary-color);">AGPL v3.0</a> | <a href="https://github.com/Webdreamjournal/DreamJournal" target="_blank" style="color: var(--primary-color);">Source Code</a>
             </p>
             <p class="app-footer p">
-                Dream Journal v1.32.10 | Not a substitute for professional medical advice
+                Dream Journal v1.32.11 | Not a substitute for professional medical advice
             </p>
         </div>
     </footer>
@@ -7338,7 +7338,7 @@ GNU Affero General Public License for more details.
                 ],
                 buttons: [
                     { text: 'Verify Titles', action: 'verify-lock-screen-dream-titles', class: 'btn-primary' },
-                    { text: '← Back', action: 'return-to-lock-screen', class: 'btn-secondary' }
+                    { text: '← Back', action: 'show-lock-screen-forgot-pin', class: 'btn-secondary' }
                 ],
                 feedbackContainer: true
             });
@@ -7405,7 +7405,7 @@ GNU Affero General Public License for more details.
                     <p class="text-secondary mb-lg line-height-relaxed">Do you want to start the 72-hour recovery timer?</p>`,
                 buttons: [
                     { text: 'Start Timer', action: 'confirm-lock-screen-timer', class: 'btn-primary' },
-                    { text: '← Cancel', action: 'return-to-lock-screen', class: 'btn-secondary' }
+                    { text: '← Cancel', action: 'show-lock-screen-forgot-pin', class: 'btn-secondary' }
                 ],
                 feedbackContainer: true
             });


### PR DESCRIPTION
The back button on the 'Verify Dream Titles' page and the cancel button on the 'Timer Reset' page were both incorrectly navigating the user back to the initial lock screen.

This was caused by both buttons using the `return-to-lock-screen` action.

This commit corrects the `data-action` attribute for both buttons to use the `show-lock-screen-forgot-pin` action, which correctly returns the user to the main PIN recovery options screen.

Additionally, the application version was incremented to v1.32.11 as per repository guidelines.