### PR TITLE
Encrypt Dropbox OAuth tokens at rest; sync version headers

### DIFF
--- a/action-router.js
+++ b/action-router.js
@@ -12,7 +12,7 @@
  * 3. Unified event delegation - Single click and change handlers for the entire app
  * 
  * @module ActionRouter
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Development Team
  * @since 2.0.0
  * @requires constants

--- a/advicetab.js
+++ b/advicetab.js
@@ -33,7 +33,7 @@
  * - Coordinates with main app initialization sequence
  * 
  * @module advicetab
- * @version 2.04.00
+ * @version 2.05.01
  * @since 2.02.44
  * @author Dream Journal Application
  */

--- a/cloud-sync.js
+++ b/cloud-sync.js
@@ -28,7 +28,7 @@
  * - dom-helpers.js: UI utilities and messaging
  *
  * @module CloudSync
- * @version 2.04.01
+ * @version 2.05.02
  * @since 2.04.01
  * @author Dream Journal Application
  * @requires Dropbox JavaScript SDK (loaded via CDN)
@@ -117,7 +117,7 @@ import {
     storePaginationPreference
 } from './dom-helpers.js';
 
-console.log('Loading Cloud Sync Module v2.04.01');
+console.log('Loading Cloud Sync Module v2.05.02');
 
 // ================================
 // DROPBOX CLIENT ID MANAGEMENT
@@ -485,10 +485,13 @@ async function handleOAuthCallback() {
  */
 async function storeTokensSecurely(tokenData) {
     try {
-        // Store tokens (will be encrypted by existing security system if enabled)
-        setDropboxAccessToken(tokenData.access_token);
+        // Encrypt with the user's encryption password when the security system is active;
+        // otherwise fall back to plaintext so the OAuth flow still works for users who
+        // haven't enabled encryption. Existing plaintext tokens remain readable because
+        // decryptTokenIfNeeded() only runs when the ENCRYPTED_TOKEN_PREFIX sentinel is present.
+        setDropboxAccessToken(await encryptTokenIfEnabled(tokenData.access_token));
         if (tokenData.refresh_token) {
-            setDropboxRefreshToken(tokenData.refresh_token);
+            setDropboxRefreshToken(await encryptTokenIfEnabled(tokenData.refresh_token));
         }
 
         // Calculate and store expiration time
@@ -501,6 +504,75 @@ async function storeTokensSecurely(tokenData) {
     } catch (error) {
         console.error('Error storing tokens:', error);
         throw error;
+    }
+}
+
+/**
+ * Sentinel prefix marking a token stored in encrypted form. Lets us
+ * distinguish encrypted payloads from legacy plaintext tokens written
+ * before real encryption was wired up, so both can coexist during upgrade.
+ * @type {string}
+ * @private
+ */
+const ENCRYPTED_TOKEN_PREFIX = 'enc:v1:';
+
+/**
+ * Encrypts a token with the user's encryption password when the security
+ * system is active, otherwise returns the plaintext token unchanged.
+ *
+ * Returns `null`/empty passthrough unchanged so callers can pass raw
+ * tokenData fields without null-checking first.
+ *
+ * @async
+ * @function
+ * @param {string|null|undefined} plainToken - Token to encrypt
+ * @returns {Promise<string|null|undefined>} Sentinel-prefixed base64 ciphertext when encrypting, or the original value
+ * @since 2.05.02
+ * @private
+ */
+async function encryptTokenIfEnabled(plainToken) {
+    if (!plainToken) return plainToken;
+    if (!getEncryptionEnabled()) return plainToken;
+    const password = getEncryptionPassword();
+    if (!password) {
+        console.warn('Encryption enabled but password unavailable; storing Dropbox token in plaintext');
+        return plainToken;
+    }
+    const encrypted = await encryptData(plainToken, password);
+    return ENCRYPTED_TOKEN_PREFIX + btoa(String.fromCharCode(...encrypted));
+}
+
+/**
+ * Decrypts a token previously written by encryptTokenIfEnabled().
+ *
+ * Returns plaintext unchanged when the sentinel prefix is absent so
+ * legacy tokens stored before encryption was enabled keep working.
+ * Returns null when the token is encrypted but the password is
+ * unavailable (e.g. app is locked) so callers can re-prompt instead
+ * of receiving ciphertext.
+ *
+ * @async
+ * @function
+ * @param {string|null|undefined} storedValue - Raw value from state.js token getter
+ * @returns {Promise<string|null>} Plaintext token, or null if unavailable/undecryptable
+ * @since 2.05.02
+ * @private
+ */
+async function decryptTokenIfNeeded(storedValue) {
+    if (!storedValue) return null;
+    if (!storedValue.startsWith(ENCRYPTED_TOKEN_PREFIX)) return storedValue;
+    const password = getEncryptionPassword();
+    if (!password) {
+        console.warn('Cannot decrypt stored Dropbox token: encryption password not available');
+        return null;
+    }
+    try {
+        const base64 = storedValue.slice(ENCRYPTED_TOKEN_PREFIX.length);
+        const binary = new Uint8Array(atob(base64).split('').map(c => c.charCodeAt(0)));
+        return await decryptData(binary, password);
+    } catch (error) {
+        console.error('Failed to decrypt stored Dropbox token:', error);
+        return null;
     }
 }
 
@@ -532,8 +604,7 @@ async function storeTokensSecurely(tokenData) {
  */
 async function getDecryptedAccessToken() {
     try {
-        const storedToken = getDropboxAccessToken();
-        return storedToken;
+        return await decryptTokenIfNeeded(getDropboxAccessToken());
     } catch (error) {
         console.error('Error retrieving access token:', error);
         throw error;
@@ -615,8 +686,7 @@ async function refreshAccessToken() {
  */
 async function getDecryptedRefreshToken() {
     try {
-        const storedToken = getDropboxRefreshToken();
-        return storedToken;
+        return await decryptTokenIfNeeded(getDropboxRefreshToken());
     } catch (error) {
         console.error('Error retrieving refresh token:', error);
         throw error;

--- a/constants.js
+++ b/constants.js
@@ -5,7 +5,7 @@
  * Maintains single source of truth for consistent behavior across modules.
  * 
  * @module constants
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Development Team
  * @since 1.0.0
  */

--- a/dom-helpers.js
+++ b/dom-helpers.js
@@ -6,7 +6,7 @@
  * HSL-based theme system and centralized event handling via data-action attributes.
  * 
  * @module DOMHelpers
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Development Team
  * @since 1.0.0
  * @requires constants

--- a/dream-crud.js
+++ b/dream-crud.js
@@ -7,7 +7,7 @@
  * optimal performance and reliability.
  * 
  * @module DreamCRUD
- * @version 2.04.00
+ * @version 2.05.01
  * @since 1.0.0
  * @requires constants
  * @requires state

--- a/goalstab.js
+++ b/goalstab.js
@@ -7,7 +7,7 @@
  * and pagination for both active and completed goals.
  * 
  * @module Goals
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Team
  * @since 1.0.0
  * @requires constants

--- a/import-export.js
+++ b/import-export.js
@@ -13,7 +13,7 @@
  * automatic format detection and user validation.
  * 
  * @module ImportExport
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Development Team
  * @since 1.0.0
  * @requires constants

--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@ GNU Affero General Public License for more details.
                 
                 <!-- Version Information and Additional Medical Disclaimer -->
                 <p>
-                    Dream Journal v2.05.01 | Not a substitute for professional medical advice
+                    Dream Journal v2.05.02 | Not a substitute for professional medical advice
                 </p>
             </div>
         </footer>

--- a/journaltab.js
+++ b/journaltab.js
@@ -11,7 +11,7 @@
  * 
  * @author Dream Journal Development Team
  * @since 2.02.06
- * @version 2.04.00
+ * @version 2.05.01
  */
 
 // Import state management function and constants for form state synchronization

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@
  * - Tab container management and dynamic content
  * 
  * @module MainApplication
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Development Team
  * @since 1.0.0
  * @requires constants
@@ -732,7 +732,7 @@ function restoreDreamFormState() {
  * @async
  * @function
  * @since 1.0.0
- * @version 2.04.00
+ * @version 2.05.01
  * @todo Consider splitting into initializeImmediateSetup() and initializeDelayedSetup() functions for better separation of fast startup vs slower initialization tasks
  * @example
  * // Called by app entry point:

--- a/pwa.js
+++ b/pwa.js
@@ -7,7 +7,7 @@
  * creating circular dependencies.
  * 
  * @module PWA
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Development Team
  * @since 2.02.22
  * @example

--- a/security.js
+++ b/security.js
@@ -17,7 +17,7 @@
  * - Password dialog system for import/export operations
  * 
  * @module Security
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Development Team
  * @since 1.0.0
  * @requires constants

--- a/settingstab.js
+++ b/settingstab.js
@@ -32,8 +32,8 @@
  * - Browser compatibility detection
  * - PWA installation integration
  * 
- * @module settingstab  
- * @version 2.04.00
+ * @module settingstab
+ * @version 2.05.01
  * @since 2.02.05
  * @author Dream Journal Application
  */

--- a/src/app.js
+++ b/src/app.js
@@ -9,7 +9,7 @@
  * the initialization logic and this file handles the DOM event binding.
  * 
  * @module AppEntryPoint
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Development Team
  * @since 2.02.05
  * @requires ./main.js

--- a/state.js
+++ b/state.js
@@ -7,7 +7,7 @@
  * concurrency control, and UI state management.
  * 
  * @module State
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Development Team
  * @since 1.0.0
  * @requires none

--- a/statstab.js
+++ b/statstab.js
@@ -20,7 +20,7 @@
  * 11. Dream Signs Analysis - Dream sign frequency and lucidity effectiveness
  * 
  * @module StatisticsModule
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Development Team
  * @since 1.0.0
  * @requires storage

--- a/storage.js
+++ b/storage.js
@@ -7,7 +7,7 @@
      * suggestions with proper error handling, validation, and migration support.
      * 
      * @module storage
-     * @version 2.04.00
+     * @version 2.05.01
      * @author Development Team
      * @since 1.0.0
      * @requires constants

--- a/sw.js
+++ b/sw.js
@@ -25,7 +25,7 @@
  * - Old caches are automatically cleaned up during activation
  * - Service worker can be force-updated via message passing
  * 
- * @version 2.04.00
+ * @version 2.05.02
  * @author Dream Journal Development Team
  * @since 2.0.0
  * @example
@@ -57,7 +57,7 @@
  * @since 2.0.0
  */
 
-const CACHE_NAME = 'dream-journal-v2-05-01';
+const CACHE_NAME = 'dream-journal-v2-05-02';
 
 /**
  * List of essential files to cache for complete offline functionality.

--- a/voice-notes.js
+++ b/voice-notes.js
@@ -11,7 +11,7 @@
  * - Cross-browser compatibility handling
  * 
  * @module VoiceNotes
- * @version 2.04.00
+ * @version 2.05.01
  * @author Dream Journal Development Team
  * @since 1.0.0
  * @requires constants


### PR DESCRIPTION
Security fix: storeTokensSecurely() and getDecrypted{Access,Refresh}Token() in cloud-sync.js previously stored and returned raw tokens despite JSDoc claiming encryption. Tokens are now encrypted with AES-256-GCM via the existing security.js primitives when the user has encryption enabled and a password available, using an enc:v1: sentinel prefix for backward compatibility with legacy plaintext tokens.

Also aligned @version JSDoc headers across all modules to 2.05.01 (they were still at 2.04.00/2.04.01 despite index.html and sw.js being at 2.05.01), then bumped all three canonical version locations to 2.05.02 for the token-encryption change.