### PR TITLE
Clear PKCE verifier on startDropboxAuth error paths

### DIFF
--- a/cloud-sync.js
+++ b/cloud-sync.js
@@ -28,7 +28,7 @@
  * - dom-helpers.js: UI utilities and messaging
  *
  * @module CloudSync
- * @version 2.05.03
+ * @version 2.05.05
  * @since 2.04.01
  * @author Dream Journal Application
  * @requires Dropbox JavaScript SDK (loaded via CDN)
@@ -117,7 +117,7 @@ import {
     storePaginationPreference
 } from './dom-helpers.js';
 
-console.log('Loading Cloud Sync Module v2.05.03');
+console.log('Loading Cloud Sync Module v2.05.05');
 
 // ================================
 // DROPBOX CLIENT ID MANAGEMENT
@@ -331,6 +331,9 @@ async function startDropboxAuth() {
 
     } catch (error) {
         console.error('Error starting Dropbox authentication:', error);
+        // Clean up PKCE verifier if it was stored before the error, so a later
+        // spurious callback cannot reuse an orphaned verifier. Safe if nothing was stored.
+        window.sessionStorage.removeItem('dropbox_code_verifier');
         createInlineMessage('error', 'Failed to start authentication. Please try again.');
         throw error;
     }

--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@ GNU Affero General Public License for more details.
                 
                 <!-- Version Information and Additional Medical Disclaimer -->
                 <p>
-                    Dream Journal v2.05.04 | Not a substitute for professional medical advice
+                    Dream Journal v2.05.05 | Not a substitute for professional medical advice
                 </p>
             </div>
         </footer>

--- a/sw.js
+++ b/sw.js
@@ -25,7 +25,7 @@
  * - Old caches are automatically cleaned up during activation
  * - Service worker can be force-updated via message passing
  * 
- * @version 2.05.04
+ * @version 2.05.05
  * @author Dream Journal Development Team
  * @since 2.0.0
  * @example
@@ -57,7 +57,7 @@
  * @since 2.0.0
  */
 
-const CACHE_NAME = 'dream-journal-v2-05-04';
+const CACHE_NAME = 'dream-journal-v2-05-05';
 
 /**
  * List of essential files to cache for complete offline functionality.


### PR DESCRIPTION
## Summary
- If `getAuthenticationUrl()` in `cloud-sync.js startDropboxAuth()` succeeded (storing the PKCE code verifier at line 321) but a later step threw — `clearAuthenticationState()`, `createInlineMessage()`, or the assignment to `window.location.href` — the verifier was left orphaned in `sessionStorage` and could be reused by a later spurious OAuth callback in the same tab session, weakening the PKCE single-flow binding.
- Added `window.sessionStorage.removeItem('dropbox_code_verifier')` to the `startDropboxAuth()` catch block before re-throwing (idempotent — safe if the error fired before the verifier was stored). `handleOAuthCallback()` already clears the verifier on both its success and error paths, so this closes the remaining gap on the start-flow side.
- Version bump 2.05.04 → 2.05.05 across `index.html` footer, `sw.js` `CACHE_NAME` + `@version`, and `cloud-sync.js` `@version` + startup console banner (cloud-sync.js was still stale at 2.05.03 from before the 2.05.04 SRI commit).

## Test plan
- [ ] Trigger an error in `startDropboxAuth()` after `getAuthenticationUrl()` succeeds (e.g. block the Dropbox redirect URL or throw inside `createInlineMessage`) and confirm `sessionStorage.getItem('dropbox_code_verifier')` is `null` afterward.
- [ ] Normal happy-path OAuth still completes: auth URL generated → redirect → callback → tokens stored → verifier cleared.
- [ ] PWA cache rotates: old `dream-journal-v2-05-04` cache is evicted on activation; new `v2-05-05` cache loads the fresh `cloud-sync.js`.
- [ ] Existing plaintext and `enc:v1:`-prefixed Dropbox tokens still decrypt correctly (no regression from 2.05.02 path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)