### PR TITLE
Serialize Dropbox token refresh and OAuth callback with promise mutex

### DIFF
--- a/cloud-sync.js
+++ b/cloud-sync.js
@@ -28,7 +28,7 @@
  * - dom-helpers.js: UI utilities and messaging
  *
  * @module CloudSync
- * @version 2.05.05
+ * @version 2.05.06
  * @since 2.04.01
  * @author Dream Journal Application
  * @requires Dropbox JavaScript SDK (loaded via CDN)
@@ -117,7 +117,7 @@ import {
     storePaginationPreference
 } from './dom-helpers.js';
 
-console.log('Loading Cloud Sync Module v2.05.05');
+console.log('Loading Cloud Sync Module v2.05.06');
 
 // ================================
 // DROPBOX CLIENT ID MANAGEMENT
@@ -169,6 +169,33 @@ let dropboxInstance = null;
  * @private
  */
 let dropboxAuth = null;
+
+/**
+ * In-flight token refresh promise, used as a single-slot mutex so that
+ * concurrent callers share one network exchange instead of each hitting
+ * the Dropbox refresh endpoint with the same refresh token.
+ *
+ * Cleared in the refresh IIFE's finally block once the exchange resolves
+ * (success or failure), so the next caller after completion starts a
+ * fresh refresh.
+ *
+ * @type {Promise<boolean>|null}
+ * @private
+ * @since 2.05.06
+ */
+let refreshTokenInFlight = null;
+
+/**
+ * In-flight OAuth code-exchange promise. Prevents `handleOAuthCallback()`
+ * from being invoked twice concurrently (e.g. double-fire on init) and
+ * sending the same single-use authorization code to Dropbox twice — the
+ * second exchange would always fail because PKCE auth codes are one-shot.
+ *
+ * @type {Promise<boolean>|null}
+ * @private
+ * @since 2.05.06
+ */
+let oauthCallbackInFlight = null;
 
 // ================================
 // AUTHENTICATION MANAGEMENT
@@ -376,79 +403,98 @@ async function startDropboxAuth() {
  * }
  */
 async function handleOAuthCallback() {
-    try {
-        // Check if we have an authorization code in the URL
-        const urlParams = new URLSearchParams(window.location.search);
-        const authCode = urlParams.get('code');
-
-        if (!authCode) {
-            console.log('No authorization code found in URL');
-            return false;
-        }
-
-        // Get stored code verifier
-        const codeVerifier = window.sessionStorage.getItem('dropbox_code_verifier');
-        if (!codeVerifier) {
-            throw new Error('Code verifier not found. Authentication may have been interrupted.');
-        }
-
-        if (!dropboxAuth) {
-            initializeDropboxAuth();
-        }
-
-        // Set the code verifier for token exchange
-        dropboxAuth.setCodeVerifier(codeVerifier);
-
-        // Exchange authorization code for tokens
-        const tokenResponse = await dropboxAuth.getAccessTokenFromCode(DROPBOX_REDIRECT_URI, authCode);
-
-        if (!tokenResponse.result.access_token) {
-            throw new Error('No access token received from Dropbox');
-        }
-
-        // Store tokens securely
-        await storeTokensSecurely(tokenResponse.result);
-
-        // Initialize Dropbox API instance
-        await initializeDropboxAPI();
-
-        // Fetch and store user account information
-        const userInfo = await fetchDropboxUserInfo();
-        if (userInfo) {
-            setDropboxUserInfo(userInfo);
-            console.log('Dropbox user info stored:', userInfo.email);
-        }
-
-        // Update authentication state
-        setCloudSyncEnabled(true);
-        setLastCloudSyncTime(Date.now());
-
-        // Clean up temporary data
-        window.sessionStorage.removeItem('dropbox_code_verifier');
-
-        // Clear URL parameters
-        window.history.replaceState({}, document.title, window.location.pathname);
-
-        // Update UI to reflect connected state
-        updateCloudSyncUI();
-
-        // Show success message
-        createInlineMessage('success', '🎉 Successfully connected to Dropbox! You can now sync your dreams to the cloud.');
-        announceLiveMessage('Successfully connected to Dropbox');
-
-        console.log('Dropbox authentication completed successfully');
-        return true;
-
-    } catch (error) {
-        console.error('Error handling OAuth callback:', error);
-        createInlineMessage('error', `Authentication failed: ${error.message}`);
-
-        // Clean up on error
-        window.sessionStorage.removeItem('dropbox_code_verifier');
-        clearAuthenticationState();
-
-        return false;
+    // Coalesce concurrent callers — PKCE authorization codes are strictly
+    // single-use, so a second exchange of the same code is guaranteed to
+    // fail at Dropbox's token endpoint. If initializeCloudSync() ever fires
+    // twice (re-init after fast back-forward navigation, hot reload, or a
+    // future auto-refresh flow), returning the shared promise avoids a
+    // spurious "invalid_grant" error wiping authenticated state.
+    if (oauthCallbackInFlight) {
+        console.log('OAuth callback already in flight; awaiting existing promise');
+        return oauthCallbackInFlight;
     }
+
+    oauthCallbackInFlight = (async () => {
+        try {
+            // Check if we have an authorization code in the URL
+            const urlParams = new URLSearchParams(window.location.search);
+            const authCode = urlParams.get('code');
+
+            if (!authCode) {
+                console.log('No authorization code found in URL');
+                return false;
+            }
+
+            // Get stored code verifier
+            const codeVerifier = window.sessionStorage.getItem('dropbox_code_verifier');
+            if (!codeVerifier) {
+                throw new Error('Code verifier not found. Authentication may have been interrupted.');
+            }
+
+            if (!dropboxAuth) {
+                initializeDropboxAuth();
+            }
+
+            // Set the code verifier for token exchange
+            dropboxAuth.setCodeVerifier(codeVerifier);
+
+            // Exchange authorization code for tokens
+            const tokenResponse = await dropboxAuth.getAccessTokenFromCode(DROPBOX_REDIRECT_URI, authCode);
+
+            if (!tokenResponse.result.access_token) {
+                throw new Error('No access token received from Dropbox');
+            }
+
+            // Store tokens securely
+            await storeTokensSecurely(tokenResponse.result);
+
+            // Initialize Dropbox API instance
+            await initializeDropboxAPI();
+
+            // Fetch and store user account information
+            const userInfo = await fetchDropboxUserInfo();
+            if (userInfo) {
+                setDropboxUserInfo(userInfo);
+                console.log('Dropbox user info stored:', userInfo.email);
+            }
+
+            // Update authentication state
+            setCloudSyncEnabled(true);
+            setLastCloudSyncTime(Date.now());
+
+            // Clean up temporary data
+            window.sessionStorage.removeItem('dropbox_code_verifier');
+
+            // Clear URL parameters
+            window.history.replaceState({}, document.title, window.location.pathname);
+
+            // Update UI to reflect connected state
+            updateCloudSyncUI();
+
+            // Show success message
+            createInlineMessage('success', '🎉 Successfully connected to Dropbox! You can now sync your dreams to the cloud.');
+            announceLiveMessage('Successfully connected to Dropbox');
+
+            console.log('Dropbox authentication completed successfully');
+            return true;
+
+        } catch (error) {
+            console.error('Error handling OAuth callback:', error);
+            createInlineMessage('error', `Authentication failed: ${error.message}`);
+
+            // Clean up on error
+            window.sessionStorage.removeItem('dropbox_code_verifier');
+            clearAuthenticationState();
+
+            return false;
+        } finally {
+            // Clear the slot so a future legitimate callback (e.g. user
+            // re-initiates auth in the same session) can proceed.
+            oauthCallbackInFlight = null;
+        }
+    })();
+
+    return oauthCallbackInFlight;
 }
 
 /**
@@ -643,38 +689,60 @@ async function getDecryptedAccessToken() {
  * }
  */
 async function refreshAccessToken() {
-    try {
-        const refreshToken = await getDecryptedRefreshToken();
-        if (!refreshToken) {
-            console.log('No refresh token available');
-            return false;
-        }
-
-        if (!dropboxAuth) {
-            initializeDropboxAuth();
-        }
-
-        // Set refresh token and request new access token
-        dropboxAuth.setRefreshToken(refreshToken);
-        const tokenResponse = await dropboxAuth.refreshAccessToken();
-
-        if (!tokenResponse.result.access_token) {
-            throw new Error('No access token received from refresh');
-        }
-
-        // Store new tokens
-        await storeTokensSecurely(tokenResponse.result);
-
-        // Update Dropbox API instance
-        await initializeDropboxAPI();
-
-        console.log('Access token refreshed successfully');
-        return true;
-
-    } catch (error) {
-        console.error('Error refreshing access token:', error);
-        return false;
+    // Coalesce concurrent callers onto a single in-flight exchange.
+    // Two simultaneous `isAuthenticated()` calls (e.g. auto-sync firing
+    // while the user clicks the manual upload button) would otherwise
+    // both see the expired token, both read the same refresh token, and
+    // both POST to Dropbox — wasting a request and racing at the
+    // storeTokensSecurely() write. If the provider ever rotates refresh
+    // tokens, the second response would also invalidate the first.
+    if (refreshTokenInFlight) {
+        console.log('Dropbox token refresh already in flight; awaiting existing promise');
+        return refreshTokenInFlight;
     }
+
+    refreshTokenInFlight = (async () => {
+        try {
+            const refreshToken = await getDecryptedRefreshToken();
+            if (!refreshToken) {
+                console.log('No refresh token available');
+                return false;
+            }
+
+            if (!dropboxAuth) {
+                initializeDropboxAuth();
+            }
+
+            // Set refresh token and request new access token
+            dropboxAuth.setRefreshToken(refreshToken);
+            const tokenResponse = await dropboxAuth.refreshAccessToken();
+
+            if (!tokenResponse.result.access_token) {
+                throw new Error('No access token received from refresh');
+            }
+
+            // Store new tokens
+            await storeTokensSecurely(tokenResponse.result);
+
+            // Update Dropbox API instance
+            await initializeDropboxAPI();
+
+            console.log('Access token refreshed successfully');
+            return true;
+
+        } catch (error) {
+            console.error('Error refreshing access token:', error);
+            return false;
+        } finally {
+            // Clear the slot so the next caller after completion starts fresh.
+            // Inside the IIFE's finally so it runs whether the body resolved
+            // or threw (the outer catch normally swallows throws and returns
+            // false, but finally guarantees cleanup either way).
+            refreshTokenInFlight = null;
+        }
+    })();
+
+    return refreshTokenInFlight;
 }
 
 /**

--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@ GNU Affero General Public License for more details.
                 
                 <!-- Version Information and Additional Medical Disclaimer -->
                 <p>
-                    Dream Journal v2.05.05 | Not a substitute for professional medical advice
+                    Dream Journal v2.05.06 | Not a substitute for professional medical advice
                 </p>
             </div>
         </footer>

--- a/sw.js
+++ b/sw.js
@@ -25,7 +25,7 @@
  * - Old caches are automatically cleaned up during activation
  * - Service worker can be force-updated via message passing
  * 
- * @version 2.05.05
+ * @version 2.05.06
  * @author Dream Journal Development Team
  * @since 2.0.0
  * @example
@@ -57,7 +57,7 @@
  * @since 2.0.0
  */
 
-const CACHE_NAME = 'dream-journal-v2-05-05';
+const CACHE_NAME = 'dream-journal-v2-05-06';
 
 /**
  * List of essential files to cache for complete offline functionality.


### PR DESCRIPTION
## Summary
- `refreshAccessToken()` in `cloud-sync.js` had no concurrency guard. Two near-simultaneous callers — e.g. an auto-sync tick firing while the user clicks the manual upload button, or background sync overlapping `isAuthenticated()` from `syncToCloud()`/`syncFromCloud()` — would both see an expired token, both read the same refresh token, and both POST to Dropbox's refresh endpoint. That wastes a round-trip, races at the `storeTokensSecurely()` write (whichever response lands second wins), and if Dropbox ever rotates refresh tokens, the second response would invalidate the first.
- Added a module-level `refreshTokenInFlight` promise. First caller runs the exchange; subsequent callers return the same promise instead of starting a new one. An IIFE `finally` clears the slot on resolution (success or failure) so the next caller after completion starts fresh.
- Applied the same in-flight promise pattern to `handleOAuthCallback()` via `oauthCallbackInFlight`. PKCE authorization codes are strictly single-use at Dropbox's token endpoint, so a re-entrant callback (hot reload, back-forward navigation re-init, or any future auto-refresh flow that calls `initializeCloudSync()` again) would exchange the already-spent code, receive `invalid_grant`, and wipe authenticated state via the catch block's `clearAuthenticationState()`. Coalescing guarantees only one exchange per page load.
- Version bump 2.05.05 → 2.05.06 across `index.html` footer, `sw.js` `CACHE_NAME` + `@version`, and `cloud-sync.js` `@version` + startup console banner.

## Test plan
- [ ] Fire two concurrent `refreshAccessToken()` calls (e.g. via devtools console) with an expired access token — observe only one `POST /oauth2/token` in Network tab and one `Access token refreshed successfully` log.
- [ ] Confirm `refreshTokenInFlight` returns to `null` after resolution (next expired-token call triggers a fresh exchange rather than hanging on the stale promise).
- [ ] Happy-path OAuth flow still completes end-to-end: redirect → callback → token exchange → `dropboxInstance` initialized → success message shown.
- [ ] Simulate `initializeCloudSync()` being called twice in the same tick with `?code=…` in the URL — only one exchange should hit Dropbox; second caller should receive the same boolean result.
- [ ] PWA cache rotates cleanly: old `dream-journal-v2-05-05` cache is evicted on activation; new `v2-05-06` cache loads the updated `cloud-sync.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)